### PR TITLE
Fix: expected scalar type Half but found BFloat16

### DIFF
--- a/pulidflux.py
+++ b/pulidflux.py
@@ -322,9 +322,10 @@ class ApplyPulidFlux:
         # Am I missing something?!
         #dtype = comfy.model_management.unet_dtype()
         dtype = model.model.diffusion_model.dtype
-        # For 8bit use bfloat16 (because ufunc_add_CUDA is not implemented)
-        if dtype in [torch.float8_e4m3fn, torch.float8_e5m2]:
-            dtype = torch.bfloat16
+        # Because of 8bit models we must check what cast type does the unet uses
+        # ZLUDA (Intel, AMD) & GPUs with compute capability < 8.0 don't support bfloat16 etc.
+        if model.model.manual_cast_dtype is not None:
+            dtype = model.model.manual_cast_dtype
 
         eva_clip.to(device, dtype=dtype)
         pulid_flux.to(device, dtype=dtype)


### PR DESCRIPTION
This fixes the "expected scalar type Half but found BFloat16" error for people that have cards that don't support bf16.
Fixes #5 and #15.
Tested on RTX Quadro 6000.